### PR TITLE
add method attribute to the json schema

### DIFF
--- a/ramls/audit.json
+++ b/ramls/audit.json
@@ -52,6 +52,9 @@
     "target_id": {
       "type": "string"
     },
+    "method": {
+      "type": "string"
+    },
     "extra_targets": {
       "type": "object"
     },


### PR DESCRIPTION
Adding "method" attribute to the json schema so cql queries work as expected.