### PR TITLE
MODAUD-12 - Prepare DB tables for Circulation Audit Logs

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -12,6 +12,34 @@
           "removeAccents": true
         }
       ]
+    },
+    {
+      "tableName": "loans",
+      "fromModuleVersion": "0.0.4"
+    },
+    {
+      "tableName": "fees_fines",
+      "fromModuleVersion": "0.0.4"
+    },
+    {
+      "tableName": "item_blocks",
+      "fromModuleVersion": "0.0.4"
+    },
+    {
+      "tableName": "patron_blocks",
+      "fromModuleVersion": "0.0.4"
+    },
+    {
+      "tableName": "manual_blocks",
+      "fromModuleVersion": "0.0.4"
+    },
+    {
+      "tableName": "requests",
+      "fromModuleVersion": "0.0.4"
+    },
+    {
+      "tableName": "notices",
+      "fromModuleVersion": "0.0.4"
     }
   ]
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -15,31 +15,269 @@
     },
     {
       "tableName": "loans",
-      "fromModuleVersion": "0.0.4"
+      "fromModuleVersion": "0.0.4",
+      "index": [
+        {
+          "fieldName": "eventId",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "userBarcode",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "itemBarcode",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "servicePointId",
+          "caseSensitive": false
+        }
+      ],
+      "ginIndex": [
+        {
+          "fieldName": "action",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ],
+      "fullTextIndex": [
+        {
+          "fieldName": "description",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     },
     {
       "tableName": "fees_fines",
-      "fromModuleVersion": "0.0.4"
+      "fromModuleVersion": "0.0.4",
+      "index": [
+        {
+          "fieldName": "eventId",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "userBarcode",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "itemBarcode",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "servicePointId",
+          "caseSensitive": false
+        }
+      ],
+      "ginIndex": [
+        {
+          "fieldName": "action",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ],
+      "fullTextIndex": [
+        {
+          "fieldName": "description",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     },
     {
       "tableName": "item_blocks",
-      "fromModuleVersion": "0.0.4"
+      "fromModuleVersion": "0.0.4",
+      "index": [
+        {
+          "fieldName": "eventId",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "userBarcode",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "itemBarcode",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "servicePointId",
+          "caseSensitive": false
+        }
+      ],
+      "ginIndex": [
+        {
+          "fieldName": "action",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ],
+      "fullTextIndex": [
+        {
+          "fieldName": "description",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     },
     {
       "tableName": "patron_blocks",
-      "fromModuleVersion": "0.0.4"
+      "fromModuleVersion": "0.0.4",
+      "index": [
+        {
+          "fieldName": "eventId",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "userBarcode",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "itemBarcode",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "servicePointId",
+          "caseSensitive": false
+        }
+      ],
+      "ginIndex": [
+        {
+          "fieldName": "action",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ],
+      "fullTextIndex": [
+        {
+          "fieldName": "description",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     },
     {
       "tableName": "manual_blocks",
-      "fromModuleVersion": "0.0.4"
+      "fromModuleVersion": "0.0.4",
+      "index": [
+        {
+          "fieldName": "eventId",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "userBarcode",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "itemBarcode",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "servicePointId",
+          "caseSensitive": false
+        }
+      ],
+      "ginIndex": [
+        {
+          "fieldName": "action",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ],
+      "fullTextIndex": [
+        {
+          "fieldName": "description",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     },
     {
       "tableName": "requests",
-      "fromModuleVersion": "0.0.4"
+      "fromModuleVersion": "0.0.4",
+      "index": [
+        {
+          "fieldName": "eventId",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "userBarcode",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "itemBarcode",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "servicePointId",
+          "caseSensitive": false
+        }
+      ],
+      "ginIndex": [
+        {
+          "fieldName": "action",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ],
+      "fullTextIndex": [
+        {
+          "fieldName": "description",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     },
     {
       "tableName": "notices",
-      "fromModuleVersion": "0.0.4"
+      "fromModuleVersion": "0.0.4",
+      "index": [
+        {
+          "fieldName": "eventId",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "userBarcode",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "itemBarcode",
+          "caseSensitive": false
+        },
+        {
+          "fieldName": "servicePointId",
+          "caseSensitive": false
+        }
+      ],
+      "ginIndex": [
+        {
+          "fieldName": "action",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ],
+      "fullTextIndex": [
+        {
+          "fieldName": "description",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
[MODAUD-12](https://issues.folio.org/browse/MODAUD-12) - Prepare DB tables for Circulation Audit Logs

* Tables for loans, fees_fines, item_blocks, patron_blocks, manual_blocks, requests, notices created

Tables were created (highlighted):
<img width="588" alt="tables" src="https://user-images.githubusercontent.com/60380420/91017027-58a2c800-e5f6-11ea-9fa5-bd283f89f37b.png">

