### PR TITLE
MODAUD-37: Fix ERROR StatusLogger Unrecognized format

### DIFF
--- a/mod-audit-server/pom.xml
+++ b/mod-audit-server/pom.xml
@@ -344,6 +344,7 @@
                   <artifact>*:*</artifact>
                   <excludes>
                     <exclude>**/log4j.properties</exclude>
+                    <exclude>**/Log4j2Plugins.dat</exclude>
                   </excludes>
                 </filter>
               </filters>


### PR DESCRIPTION
Simple change to get rid of `ERROR StatusLogger Unrecognized format` in the log.