### PR TITLE
MODAUD-50 - Update Age to lost data in Circulation log

### DIFF
--- a/mod-audit-server/src/main/java/org/folio/builder/service/LoanRecordBuilder.java
+++ b/mod-audit-server/src/main/java/org/folio/builder/service/LoanRecordBuilder.java
@@ -66,7 +66,7 @@ public class LoanRecordBuilder extends LogRecordBuilder {
         .withLoanId(getProperty(payload, LOAN_ID))))
       .withAction(resolveAction(getProperty(payload, ACTION)))
       .withDate(getDateTimeProperty(payload, DATE).toDate())
-      .withServicePointId(getProperty(payload, SERVICE_POINT_ID))
+      .withServicePointId(isAction(payload, AGE_TO_LOST) ? null : getProperty(payload, SERVICE_POINT_ID))
       .withSource(isAction(payload, ANONYMIZE) || isAction(payload, AGE_TO_LOST) ? SYSTEM : getProperty(payload, PERSONAL_NAME))
       .withDescription(getProperty(payload, DESCRIPTION))
       .withLinkToIds(new LinkToIds().withUserId(getProperty(payload, USER_ID)))));

--- a/mod-audit-server/src/test/java/org/folio/builder/service/LoanRecordBuilderTest.java
+++ b/mod-audit-server/src/test/java/org/folio/builder/service/LoanRecordBuilderTest.java
@@ -92,7 +92,7 @@ public class LoanRecordBuilderTest extends BuilderTestBase {
     assertThat(loanLogRecord.getObject(), equalTo(LogRecord.Object.LOAN));
     assertThat(loanLogRecord.getAction(), equalTo(AGE_TO_LOST));
     assertThat(loanLogRecord.getDate(), is(not(nullValue())));
-    assertThat(loanLogRecord.getServicePointId(), equalTo("c4c90014-c8c9-4ade-8f24-b5e313319f4b"));
+    assertThat(loanLogRecord.getServicePointId(), nullValue());
     assertThat(loanLogRecord.getSource(), equalTo(SYSTEM));
   }
 


### PR DESCRIPTION
[MODAUD-50](https://issues.folio.org/browse/MODAUD-50) - Update Age to lost data in Circulation log

## Purpose
The Age to lost filter should NOT show Service point data since it is an automated process

## Approach
Service point data is being removed for Age to lost loan actions

Verified on local test env:
<img width="1437" alt="empty service point" src="https://user-images.githubusercontent.com/60380420/100905374-0c123700-34d9-11eb-9ec1-9a574e80dd65.png">


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
