### PR TITLE
MODAUD-79 - Both Expired and Pickup expired request statuses are show…

### DIFF
--- a/mod-audit-server/src/main/java/org/folio/builder/service/RequestRecordBuilder.java
+++ b/mod-audit-server/src/main/java/org/folio/builder/service/RequestRecordBuilder.java
@@ -8,6 +8,7 @@ import static org.folio.builder.LogRecordBuilderResolver.REQUEST_EXPIRED;
 import static org.folio.builder.LogRecordBuilderResolver.REQUEST_MOVED;
 import static org.folio.builder.LogRecordBuilderResolver.REQUEST_REORDERED;
 import static org.folio.builder.LogRecordBuilderResolver.REQUEST_UPDATED;
+import static org.folio.rest.jaxrs.model.LogRecord.Action.PICKUP_EXPIRED;
 import static org.folio.util.Constants.CANCELLATION_REASONS_URL;
 import static org.folio.util.Constants.SYSTEM;
 import static org.folio.util.JsonPropertyFetcher.getArrayProperty;
@@ -61,6 +62,7 @@ import io.vertx.core.json.JsonObject;
 public class RequestRecordBuilder extends LogRecordBuilder {
 
   public static final String CLOSED_CANCELLED_STATUS = "Closed - Cancelled";
+  public static final String PICKUP_EXPIRED_STATUS = "Closed - Pickup expired";
   RequestDescriptionBuilder requestDescriptionBuilder = new RequestDescriptionBuilder();
 
   public RequestRecordBuilder(Map<String, String> okapiHeaders, Context vertxContext) {
@@ -160,7 +162,7 @@ public class RequestRecordBuilder extends LogRecordBuilder {
             getProperty(original, REQUESTER_ID), getNestedStringProperty(updated, METADATA, UPDATED_BY_USER_ID)).thenApply(user -> {
 
               records.add(buildBaseContent(original, item, user).withSource(SYSTEM)
-                .withAction(action)
+                .withAction(PICKUP_EXPIRED_STATUS.equals(getProperty(updated, STATUS)) ? PICKUP_EXPIRED : action)
                 .withDescription(requestDescriptionBuilder.buildExpiredDescription(original, updated)));
               return records;
             }));

--- a/mod-audit-server/src/test/java/org/folio/builder/service/RequestRecordBuilderTest.java
+++ b/mod-audit-server/src/test/java/org/folio/builder/service/RequestRecordBuilderTest.java
@@ -6,6 +6,7 @@ import static org.folio.utils.TenantApiTestUtil.REQUEST_CREATED_PAYLOAD_JSON;
 import static org.folio.utils.TenantApiTestUtil.REQUEST_EDITED_PAYLOAD_JSON;
 import static org.folio.utils.TenantApiTestUtil.REQUEST_EXPIRED_PAYLOAD_JSON;
 import static org.folio.utils.TenantApiTestUtil.REQUEST_MOVED_PAYLOAD_JSON;
+import static org.folio.utils.TenantApiTestUtil.REQUEST_PICKUP_EXPIRED_PAYLOAD_JSON;
 import static org.folio.utils.TenantApiTestUtil.REQUEST_REORDERED_PAYLOAD_JSON;
 import static org.folio.utils.TenantApiTestUtil.getFile;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,7 +34,8 @@ public class RequestRecordBuilderTest extends BuilderTestBase {
   private static final String EXPECTED_MOVED_DESCRIPTION = "Type: Hold. New item barcode: 645398607547 (from: 653285216743).";
   private static final String EXPECTED_CANCELLED_DESCRIPTION = "Type: Hold. Reason for cancellation: Cancelled at patron’s request.";
   private static final String EXPECTED_REORDERED_DESCRIPTION = "Type: Recall. New queue position: 2 (from: 3).";
-  private static final String EXPECTED_EXPIRED_DESCRIPTION = "Type: Hold. New request status: Closed - Pickup expired (from: Open - Awaiting pickup).";
+  private static final String EXPECTED_EXPIRED_DESCRIPTION = "Type: Hold. New request status: Closed - Unfilled (from: Open - Awaiting pickup).";
+  private static final String EXPECTED_PICKUP_EXPIRED_DESCRIPTION = "Type: Hold. New request status: Closed - Pickup expired (from: Open - Awaiting pickup).";
 
   private enum TestValue {
 
@@ -42,7 +44,8 @@ public class RequestRecordBuilderTest extends BuilderTestBase {
     MOVED(LogRecord.Action.MOVED, REQUEST_MOVED_PAYLOAD_JSON, EXPECTED_MOVED_DESCRIPTION),
     CANCELLED(LogRecord.Action.CANCELLED, REQUEST_CANCELLED_PAYLOAD_JSON, EXPECTED_CANCELLED_DESCRIPTION),
     REORDERED(LogRecord.Action.QUEUE_POSITION_REORDERED, REQUEST_REORDERED_PAYLOAD_JSON, EXPECTED_REORDERED_DESCRIPTION),
-    EXPIRED(LogRecord.Action.EXPIRED, REQUEST_EXPIRED_PAYLOAD_JSON, EXPECTED_EXPIRED_DESCRIPTION);
+    EXPIRED(LogRecord.Action.EXPIRED, REQUEST_EXPIRED_PAYLOAD_JSON, EXPECTED_EXPIRED_DESCRIPTION),
+    PICKUP_EXPIRED(LogRecord.Action.PICKUP_EXPIRED, REQUEST_PICKUP_EXPIRED_PAYLOAD_JSON, EXPECTED_PICKUP_EXPIRED_DESCRIPTION);
 
     TestValue(LogRecord.Action action, String pathToPayload, String description) {
       this.action = action;
@@ -89,7 +92,7 @@ public class RequestRecordBuilderTest extends BuilderTestBase {
     assertThat(requestLogRecord.getLinkToIds().getUserId(), notNullValue());
     assertThat(requestLogRecord.getLinkToIds().getRequestId(), notNullValue());
 
-    if (TestValue.EXPIRED == value) {
+    if (TestValue.EXPIRED == value || TestValue.PICKUP_EXPIRED == value) {
       assertThat(requestLogRecord.getSource(), equalTo(SYSTEM));
     } else {
       assertThat(requestLogRecord.getSource(), equalTo("ADMINISTRATOR, DIKU"));

--- a/mod-audit-server/src/test/java/org/folio/utils/TenantApiTestUtil.java
+++ b/mod-audit-server/src/test/java/org/folio/utils/TenantApiTestUtil.java
@@ -54,6 +54,7 @@ public class TenantApiTestUtil {
   public static final String REQUEST_REORDERED_PAYLOAD_JSON = "payloads/request_reordered.json";
   public static final String REQUEST_CANCELLED_PAYLOAD_JSON = "payloads/request_cancelled.json";
   public static final String REQUEST_EXPIRED_PAYLOAD_JSON = "payloads/request_expired.json";
+  public static final String REQUEST_PICKUP_EXPIRED_PAYLOAD_JSON = "payloads/request_pickup_expired.json";
 
   public static final String ANONYMIZE_CHECK_IN = "payloads/anonymize_check_in.json";
   public static final String ANONYMIZE_CHECK_OUT = "payloads/anonymize_check_out.json";

--- a/mod-audit-server/src/test/resources/payloads/request_pickup_expired.json
+++ b/mod-audit-server/src/test/resources/payloads/request_pickup_expired.json
@@ -25,7 +25,7 @@
         "requestDate":1500111327000,
         "requesterId":"6f36265e-722a-490a-b436-806e63af2ea7",
         "itemId":"100d10bf-2f06-4aa0-be15-0b95b2d9f9e3",
-        "status":"Closed - Unfilled",
+        "status":"Closed - Pickup expired",
         "fulfilmentPreference":"Hold Shelf",
         "holdShelfExpirationDate":1501410174000,
         "metadata":{


### PR DESCRIPTION
[MODAUD-79](https://issues.folio.org/browse/MODAUD-79) - Both Expired and Pickup expired request statuses are shown as Expired in circulation log

## Purpose
Circulation audit log should distinguish between Expired and Pickup expired request statuses and save correct values.

## Approach
* fixed request record builder

Verified on local testing environment:
<img width="1435" alt="Screenshot 2021-04-26 at 17 37 00" src="https://user-images.githubusercontent.com/60380420/116112755-86c63380-a6c0-11eb-8d11-827380edf69a.png">


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
