### PR TITLE
MODAUD-69 - mod_audit.circulation_logs query utilizing excessive DB CPU

### DIFF
--- a/mod-audit-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-audit-server/src/main/resources/templates/db_scripts/schema.json
@@ -15,11 +15,11 @@
     },
     {
       "tableName": "circulation_logs",
-      "fromModuleVersion": "0.0.4",
+      "fromModuleVersion": "2.4.0",
       "ginIndex": [
         {
           "fieldName": "items",
-          "tOps": "ADD",
+          "tOps": "DELETE",
           "caseSensitive": false,
           "removeAccents": true,
           "arraySubfield": "itemBarcode",
@@ -51,6 +51,12 @@
       "fullTextIndex": [
         {
           "fieldName": "description",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "items",
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": true


### PR DESCRIPTION
[MODAUD-69](https://issues.folio.org/browse/MODAUD-69) - mod_audit.circulation_logs query utilizing excessive DB CPU

## Purpose
Improve CPU utilizating due to using of RMB ginIndex.

## Approach
Changing items index from ginIndex to fullTextIndex. Previously identified by @sduvvuri-ebsco @evaluk and @hjiebsco  that changing of ginIndex:
```
CREATE INDEX circulation_logs_items_idx_gin
    ON fs00001034_mod_audit.circulation_logs USING gin

(lower(fs00001034_mod_audit.f_unaccent(jsonb ->> 'items'::text)) COLLATE pg_catalog."default" gin_trgm_ops) TABLESPACE pg_default;
```
to fullTextIndex
```
CREATE INDEX circulation_logs_items_idx_2
    ON fs00001034_mod_audit.circulation_logs USING gin

    (fs00001034_mod_audit.get_tsvector(fs00001034_mod_audit.f_unaccent(jsonb ->> 'items'::text)))TABLESPACE pg_default;
```
significantly improves performance.


#### TODOS and Open Questions
- [ ] gin_trgm_ops from RMB negatively affects performance?

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
