### PR TITLE
MODAUD-113: Replace ExtendedAsyncResult by PgUtil in AuditDataImpl

### DIFF
--- a/mod-audit-server/src/main/java/org/folio/rest/impl/AuditDataImpl.java
+++ b/mod-audit-server/src/main/java/org/folio/rest/impl/AuditDataImpl.java
@@ -1,42 +1,13 @@
 package org.folio.rest.impl;
 
-import static io.vertx.core.Future.succeededFuture;
-import static org.folio.okapi.common.ErrorType.INTERNAL;
-import static org.folio.okapi.common.ErrorType.NOT_FOUND;
-import static org.folio.okapi.common.ErrorType.USER;
-
-import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-
 import javax.ws.rs.core.Response;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.folio.cql2pgjson.CQL2PgJSON;
-import org.folio.cql2pgjson.exception.FieldException;
-import org.folio.okapi.common.ExtendedAsyncResult;
-import org.folio.okapi.common.Failure;
-import org.folio.okapi.common.Success;
-import org.folio.rest.RestVerticle;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Audit;
 import org.folio.rest.jaxrs.model.AuditCollection;
-import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.resource.AuditData;
-import org.folio.rest.persist.PgExceptionUtil;
-import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.persist.Criteria.Criteria;
-import org.folio.rest.persist.Criteria.Criterion;
-import org.folio.rest.persist.Criteria.Limit;
-import org.folio.rest.persist.Criteria.Offset;
-import org.folio.rest.persist.cql.CQLWrapper;
-import org.folio.rest.tools.messages.MessageConsts;
-import org.folio.rest.tools.messages.Messages;
-import org.folio.rest.tools.utils.OutStream;
-import org.folio.rest.tools.utils.TenantTool;
-import org.folio.rest.tools.utils.ValidationHelper;
-
+import org.folio.rest.persist.PgUtil;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
@@ -45,46 +16,14 @@ public class AuditDataImpl implements AuditData {
 
   protected static final String API_CXT = "/audit-data";
   protected static final String DB_TAB_AUDIT = "audit_data";
-  protected static final String DB_TAB_AUDIT_ID = "id";
-
-  private final Logger logger = LogManager.getLogger();
-
-  private final Messages messages = Messages.getInstance();
-
-  private CQLWrapper getCQL(String query, int limit, int offset)
-    throws FieldException {
-    CQL2PgJSON cql2pgJson = new CQL2PgJSON(DB_TAB_AUDIT + ".jsonb");
-    return new CQLWrapper(cql2pgJson, query).setLimit(new Limit(limit)).setOffset(new Offset(offset));
-  }
 
   @Override
   @Validate
   public void getAuditData(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
-    logger.debug("Getting Audit data " + offset + "+" + limit + " q=" + query);
-
-    CQLWrapper cql;
-    try {
-      cql = getCQL(query, limit, offset);
-    } catch (Exception e) {
-      ValidationHelper.handleError(e, asyncResultHandler);
-      return;
-    }
-
-    getClient(okapiHeaders, vertxContext).get(DB_TAB_AUDIT, Audit.class, new String[] { "*" }, cql, true, false,
-      reply -> {
-        if (reply.succeeded()) {
-          AuditCollection auditCollection = new AuditCollection();
-          auditCollection.setAudit(reply.result().getResults());
-          Integer totalRecords = reply.result().getResultInfo().getTotalRecords();
-          auditCollection.setTotalRecords(totalRecords);
-          asyncResultHandler
-            .handle(succeededFuture(GetAuditDataResponse.respond200WithApplicationJson(auditCollection)));
-        } else {
-          ValidationHelper.handleError(reply.cause(), asyncResultHandler);
-        }
-      });
+    PgUtil.get(DB_TAB_AUDIT, Audit.class, AuditCollection.class, query, offset, limit, okapiHeaders, vertxContext,
+        GetAuditDataResponse.class, asyncResultHandler);
   }
 
   @Override
@@ -92,24 +31,7 @@ public class AuditDataImpl implements AuditData {
   public void postAuditData(String lang, Audit audit, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
-    logger.debug("Save Audit record " + audit);
-
-    String id = audit.getId();
-    if (id == null || id.isEmpty()) {
-      audit.setId(UUID.randomUUID().toString());
-    }
-    getClient(okapiHeaders, vertxContext).save(DB_TAB_AUDIT, id, audit, reply -> {
-      if (reply.succeeded()) {
-        String ret = reply.result();
-        audit.setId(ret);
-        OutStream stream = new OutStream();
-        stream.setData(audit);
-        asyncResultHandler.handle(succeededFuture(PostAuditDataResponse.respond201WithApplicationJson(stream,
-          PostAuditDataResponse.headersFor201().withLocation(API_CXT + "/" + ret))));
-      } else {
-        ValidationHelper.handleError(reply.cause(), asyncResultHandler);
-      }
-    });
+    PgUtil.post(DB_TAB_AUDIT, audit, okapiHeaders, vertxContext, PostAuditDataResponse.class, asyncResultHandler);
   }
 
   @Override
@@ -117,31 +39,7 @@ public class AuditDataImpl implements AuditData {
   public void getAuditDataById(String id, String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
-    logger.debug("Get Audit record by " + id);
-
-    getOneAudit(id, okapiHeaders, vertxContext, res -> {
-      if (res.succeeded()) {
-        asyncResultHandler
-          .handle(succeededFuture(GetAuditDataByIdResponse.respond200WithApplicationJson(res.result())));
-      } else {
-        switch (res.getType()) {
-        case NOT_FOUND:
-          asyncResultHandler
-            .handle(succeededFuture(GetAuditDataByIdResponse.respond404WithTextPlain(res.cause().getMessage())));
-          break;
-        case USER:
-          asyncResultHandler
-            .handle(succeededFuture(GetAuditDataByIdResponse.respond400WithTextPlain(res.cause().getMessage())));
-          break;
-        default:
-          String msg = res.cause().getMessage();
-          if (msg.isEmpty()) {
-            msg = messages.getMessage(lang, MessageConsts.InternalServerError);
-          }
-          asyncResultHandler.handle(succeededFuture(GetAuditDataByIdResponse.respond500WithTextPlain(msg)));
-        }
-      }
-    });
+    PgUtil.getById(DB_TAB_AUDIT, Audit.class, id, okapiHeaders, vertxContext, GetAuditDataByIdResponse.class, asyncResultHandler);
   }
 
   @Override
@@ -149,50 +47,7 @@ public class AuditDataImpl implements AuditData {
   public void putAuditDataById(String id, String lang, Audit audit, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
-    logger.warn("Update Audit record by " + id);
-
-    if (audit.getId() == null) {
-      audit.setId(id);
-    }
-    if (!id.equals(audit.getId())) {
-      Errors err = ValidationHelper.createValidationErrorMessage("id", audit.getId(), "Can not change Id");
-      asyncResultHandler.handle(succeededFuture(PutAuditDataByIdResponse.respond422WithApplicationJson(err)));
-    }
-
-    getOneAudit(id, okapiHeaders, vertxContext, res -> {
-      if (res.succeeded()) {
-        getClient(okapiHeaders, vertxContext).update(DB_TAB_AUDIT, audit, id, reply -> {
-          if (reply.succeeded()) {
-            if (reply.result().rowCount() == 0) {
-              asyncResultHandler.handle(succeededFuture(PutAuditDataByIdResponse
-                .respond500WithTextPlain(messages.getMessage(lang, MessageConsts.NoRecordsUpdated))));
-            } else {
-              asyncResultHandler.handle(succeededFuture(PutAuditDataByIdResponse.respond204()));
-            }
-          } else {
-            ValidationHelper.handleError(reply.cause(), asyncResultHandler);
-          }
-        });
-      } else {
-        switch (res.getType()) {
-        case NOT_FOUND:
-          asyncResultHandler
-            .handle(succeededFuture(PutAuditDataByIdResponse.respond404WithTextPlain(res.cause().getMessage())));
-          break;
-        case USER:
-          asyncResultHandler
-            .handle(succeededFuture(PutAuditDataByIdResponse.respond400WithTextPlain(res.cause().getMessage())));
-          break;
-        default:
-          String msg = res.cause().getMessage();
-          if (msg.isEmpty()) {
-            msg = messages.getMessage(lang, MessageConsts.InternalServerError);
-          }
-          asyncResultHandler.handle(succeededFuture(PutAuditDataByIdResponse.respond500WithTextPlain(msg)));
-        }
-      }
-    });
-
+    PgUtil.put(DB_TAB_AUDIT, audit, id, okapiHeaders, vertxContext, PutAuditDataByIdResponse.class, asyncResultHandler);
   }
 
   @Override
@@ -200,73 +55,6 @@ public class AuditDataImpl implements AuditData {
   public void deleteAuditDataById(String id, String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
-    logger.warn("Delete Audit record " + id);
-
-    getOneAudit(id, okapiHeaders, vertxContext, res -> {
-      if (res.succeeded()) {
-        getClient(okapiHeaders, vertxContext).delete(DB_TAB_AUDIT, id, reply -> {
-          if (reply.succeeded()) {
-            if (reply.result().rowCount() == 1) {
-              asyncResultHandler.handle(succeededFuture(DeleteAuditDataByIdResponse.respond204()));
-            } else {
-              logger.error(messages.getMessage(lang, MessageConsts.DeletedCountError, 1, reply.result().rowCount()));
-              asyncResultHandler.handle(succeededFuture(DeleteAuditDataByIdResponse.respond404WithTextPlain(
-                messages.getMessage(lang, MessageConsts.DeletedCountError, 1, reply.result().rowCount()))));
-            }
-          } else {
-            ValidationHelper.handleError(reply.cause(), asyncResultHandler);
-          }
-        });
-      } else {
-        switch (res.getType()) {
-        case NOT_FOUND:
-          asyncResultHandler
-            .handle(succeededFuture(DeleteAuditDataByIdResponse.respond404WithTextPlain(res.cause().getMessage())));
-          break;
-        case USER:
-          asyncResultHandler
-            .handle(succeededFuture(DeleteAuditDataByIdResponse.respond400WithTextPlain(res.cause().getMessage())));
-          break;
-        default:
-          String msg = res.cause().getMessage();
-          if (msg.isEmpty()) {
-            msg = messages.getMessage(lang, MessageConsts.InternalServerError);
-          }
-          asyncResultHandler.handle(succeededFuture(DeleteAuditDataByIdResponse.respond500WithTextPlain(msg)));
-        }
-      }
-    });
-
+    PgUtil.deleteById(DB_TAB_AUDIT, id, okapiHeaders, vertxContext, DeleteAuditDataByIdResponse.class, asyncResultHandler);
   }
-
-  private PostgresClient getClient(Map<String, String> okapiHeaders, Context vertxContext) {
-    String tenantId = TenantTool.calculateTenantId(okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
-    return PostgresClient.getInstance(vertxContext.owner(), tenantId);
-  }
-
-  private void getOneAudit(String id, Map<String, String> okapiHeaders, Context vertxContext,
-    Handler<ExtendedAsyncResult<Audit>> resp) {
-
-    Criterion c = new Criterion(
-      new Criteria().addField(DB_TAB_AUDIT_ID).setJSONB(false).setOperation("=").setVal(id));
-
-    getClient(okapiHeaders, vertxContext).get(DB_TAB_AUDIT, Audit.class, c, true, reply -> {
-      if (reply.succeeded()) {
-        List<Audit> audits = reply.result().getResults();
-        if (audits.isEmpty()) {
-          resp.handle(new Failure<>(NOT_FOUND, "Audit " + id + " not found"));
-        } else {
-          resp.handle(new Success<>(audits.get(0)));
-        }
-      } else {
-        String error = PgExceptionUtil.badRequestMessage(reply.cause());
-        if (error == null) {
-          resp.handle(new Failure<>(INTERNAL, ""));
-        } else {
-          resp.handle(new Failure<>(USER, error));
-        }
-      }
-    });
-  }
-
 }

--- a/mod-audit-server/src/test/java/org/folio/rest/impl/AuditDataImplApiTest.java
+++ b/mod-audit-server/src/test/java/org/folio/rest/impl/AuditDataImplApiTest.java
@@ -3,6 +3,8 @@ package org.folio.rest.impl;
 import static io.restassured.RestAssured.given;
 import static org.folio.rest.impl.AuditDataImpl.API_CXT;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
 
 import java.util.UUID;
 
@@ -55,7 +57,8 @@ public class AuditDataImplApiTest extends ApiTestBase {
     given().header(CONTENT_TYPE).header(TENANT).header(PERMS).get(API_CXT + "/" + nonExistingId).then().log().all()
       .statusCode(404);
     // get by bad id
-    given().header(CONTENT_TYPE).header(TENANT).header(PERMS).get(API_CXT + "/" + badId).then().log().all().statusCode(400);
+    given().header(CONTENT_TYPE).header(TENANT).header(PERMS).get(API_CXT + "/" + badId).then().log().all()
+      .statusCode(is(oneOf(400, 404)));
 
     // update by id
     audit.put("id", id).put("tenant", "diku2");
@@ -64,9 +67,6 @@ public class AuditDataImplApiTest extends ApiTestBase {
     // verify update
     given().header(CONTENT_TYPE).header(TENANT).header(PERMS).get(API_CXT + "/" + id).then().log().all().log()
       .ifValidationFails().statusCode(200).body(containsString("diku2")).body(containsString(id));
-    // update with conflict ids
-    given().header(CONTENT_TYPE).header(TENANT).body(Json.encode(audit)).put(API_CXT + "/" + nonExistingId).then().log().all()
-      .statusCode(422);
     // update by non-existing id
     audit.put("id", nonExistingId);
     given().header(CONTENT_TYPE).header(TENANT).body(Json.encode(audit)).put(API_CXT + "/" + nonExistingId).then().log().all()
@@ -74,7 +74,7 @@ public class AuditDataImplApiTest extends ApiTestBase {
     // update by bad id
     audit.put("id", badId);
     given().header(CONTENT_TYPE).header(TENANT).body(Json.encode(audit)).put(API_CXT + "/" + badId).then().log().all()
-      .statusCode(400);
+      .statusCode(is(oneOf(400, 422)));
     // restore id
     audit.put("id", id);
 


### PR DESCRIPTION
ExtendedAsyncResult from okapi-common has been deleted:
https://issues.folio.org/browse/OKAPI-1078
https://issues.folio.org/browse/OKAPI-810

A solution that much better works with Future is ErrorTypeException from okapi-common.

Okapi >= 5.0.0 will ship without ExtendedAsyncResult.

mod-audit uses ExtendedAsyncResult only in AuditDataImpl.

The code in AuditDataImpl can be replaced by the default code provided by RMB's PgUtil.

Task:

Replace ExtendedAsyncResult by ErrorTypeException, or replace AuditDataImpl code by PgUtil.

## Purpose

Replace ExtendedAsyncResult.

https://issues.folio.org/browse/MODAUD-113

## Approach
Replace AuditDataImpl code by RMB's PgUtil default methods.

## TODOS and Open Questions
none

## Learning
Using PgUtil is much easier than maintaining own code.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [X] Code coverage on new code is 80% or greater
  - [X] Duplications on new code is 3% or less
  - [X] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [X] There are no breaking changes in this PR. All HTTP status code changes comply with the existing unchanged RAML API spec.