### PR TITLE
MODAUD-129: Support holdings-storage 6.0 interface

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -32,7 +32,7 @@
     },
     {
       "id": "holdings-storage",
-      "version": "4.4 5.0"
+      "version": "4.4 5.0 6.0"
     },
     {
       "id": "cancellation-reason-storage",


### PR DESCRIPTION
mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

mod-audit only uses the holdings-storage interfaces, it doesn't use the two other interfaces.

mod-audit is not affected because the incompatible change is in the DELETE all APIs only that is not used by mod-audit.

Only the okapiInterfaces need to be bumped in "requires" section of ModuleDescriptor-template.json