### PR TITLE
Remove comma from user interface expectations list MODAUD-128

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -20,7 +20,7 @@
     },
     {
       "id": "users",
-      "version": "15.2, 16.0"
+      "version": "15.2 16.0"
     },
     {
       "id": "template-engine",


### PR DESCRIPTION
## Purpose

Fix a [broken module descriptor](https://jenkins-aws.indexdata.com/job/folio-org/job/mod-audit/job/master/129) due to a comma separating the expected versions of the `users` interface.