### PR TITLE
MODAUD-135: json-path 2.7.0 fixing json-smart DoS CVE-2021-27568

### DIFF
--- a/mod-audit-server/pom.xml
+++ b/mod-audit-server/pom.xml
@@ -19,7 +19,7 @@
   </licenses>
 
   <properties>
-    <json.path.version>2.5.0</json.path.version>
+    <json.path.version>2.7.0</json.path.version>
     <postgres-testing.version>33.0.0</postgres-testing.version>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <awaitility.version>4.2.0</awaitility.version>
@@ -85,6 +85,7 @@
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
       <version>${json.path.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>


### PR DESCRIPTION
Upgrade com.jayway.jsonpath:json-path from 2.5.0 to 2.7.0. This indirectly upgrades net.minidev:json-smart from 2.3 to 2.4.7 fixing Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/cve-2021-27568

Adding <scope>test</scope> as json-path/json-smart is used in tests only.

https://issues.folio.org/browse/MODAUD-135

## Learning
json-path 2.7.0 has been available since Jan 30, 2022.
mod-audit should have upgraded its dependencies for [mod-audit v2.3.0](https://github.com/folio-org/mod-audit/releases/tag/v2.3.0) released Feb 23, 2022 and for [mod-audit v2.4.0](https://github.com/folio-org/mod-audit/releases/tag/v2.4.0) released May 23, 2022 and for [mod-audit v2.5.0](https://github.com/folio-org/mod-audit/releases/tag/v2.5.0) released Jul 08, 2022.
Please upgrade all dependencies before making the release for the next flower version.