### PR TITLE
MODAUD-140. Create tables to store audit logs for orders and order lines

### DIFF
--- a/mod-audit-server/src/main/resources/templates/db_scripts/acquisition/create_acquisition_order_line_log_table.sql
+++ b/mod-audit-server/src/main/resources/templates/db_scripts/acquisition/create_acquisition_order_line_log_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS acquisition_order_line_log (
+    id uuid PRIMARY KEY,
+    action text NOT NULL,
+    order_id uuid NOT NULL,
+    order_line_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    event_date timestamp NOT NULL,
+    action_date timestamp NOT NULL,
+    modified_content_snapshot jsonb
+);
+
+CREATE INDEX IF NOT EXISTS order_line_id_index ON acquisition_order_line_log USING BTREE (order_line_id);

--- a/mod-audit-server/src/main/resources/templates/db_scripts/acquisition/create_acquisition_order_log_table.sql
+++ b/mod-audit-server/src/main/resources/templates/db_scripts/acquisition/create_acquisition_order_log_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS acquisition_order_log (
+    id uuid PRIMARY KEY,
+    action text NOT NULL,
+    order_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    event_date timestamp NOT NULL,
+    action_date timestamp NOT NULL,
+    modified_content_snapshot jsonb
+);
+
+CREATE INDEX IF NOT EXISTS order_id_index ON acquisition_order_log USING BTREE (order_id);
+

--- a/mod-audit-server/src/main/resources/templates/db_scripts/acquisition/create_acquisition_order_log_table.sql
+++ b/mod-audit-server/src/main/resources/templates/db_scripts/acquisition/create_acquisition_order_log_table.sql
@@ -9,4 +9,3 @@ CREATE TABLE IF NOT EXISTS acquisition_order_log (
 );
 
 CREATE INDEX IF NOT EXISTS order_id_index ON acquisition_order_log USING BTREE (order_id);
-

--- a/mod-audit-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-audit-server/src/main/resources/templates/db_scripts/schema.json
@@ -63,5 +63,17 @@
         }
       ]
     }
+  ],
+  "scripts": [
+    {
+      "run": "after",
+      "snippetPath": "acquisition/create_acquisition_order_log_table.sql",
+      "fromModuleVersion": "mod-audit-2.7.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "acquisition/create_acquisition_order_line_log_table.sql",
+      "fromModuleVersion": "mod-audit-2.7.0"
+    }
   ]
 }


### PR DESCRIPTION
https://issues.folio.org/browse/MODAUD-140

Related doc that describes schema: https://wiki.folio.org/display/DD/Orders+Event+Log 

Created locally acquisition_order_line_log table:
![image](https://user-images.githubusercontent.com/25097693/203802874-23f0e121-ecdc-4473-8213-b8aab1f45151.png)
![image](https://user-images.githubusercontent.com/25097693/203803292-9de89895-38fc-4287-8e65-83e994e2b39e.png)

Created locally acquisition_order_log table:
![image](https://user-images.githubusercontent.com/25097693/203803202-5d77b0ff-3ee6-47f4-a293-73071154f838.png)
![image](https://user-images.githubusercontent.com/25097693/203803392-2578a6d4-7340-4705-b427-efcc5751e416.png)
