### PR TITLE
MODAUD-185: Unpin jackson fixing Number Parse DoS (PRISMA-2023-0067)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
     <wiremock.version>2.25.1</wiremock.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <rest-assured.version>5.4.0</rest-assured.version>
-    <jackson.version>2.14.1</jackson.version>
     <pubsub.client.version>2.13.0</pubsub.client.version>
     <streamx.version>0.7.3</streamx.version>
     <main.basedir>${project.basedir}</main.basedir>
@@ -35,13 +34,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>${jackson.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODAUD-185

jackson-core package versions before 2.15.0 are vulnerable to Denial of Service (DoS): https://github.com/FasterXML/jackson-core/pull/827

mod-audit pins the jackson version to 2.14.1. This effectively downgrades the jackson version provided by RMB (domain-models-runtime, domain-models-api-interfaces) from 2.16.1 to 2.14.1.

Fix: Unpin jackson.

## Purpose
Upgrade jacksing to fix a security vulnerability.

## Approach
Unpin jackson version.

## Learning
Don't pin a dependency version if the dependency is provided by RMB or Spring.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  - [ ] Check logging