### PR TITLE
MODAUD-250 - Version history of "MARC" records is not tracked

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2.12.0-SNAPSHOT 2025-mm-dd
+* [MODAUD-250](https://folio-org.atlassian.net/browse/MODAUD-250) - Version history of "MARC" records is not tracked
+
 ## 2.11.0 2025-03-14
 * [MODAUD-205](https://folio-org.atlassian.net/browse/MODAUD-205) - Consume domain event for MARC_BIB and MARC_AUTHORITY
 * [MODAUD-231](https://folio-org.atlassian.net/browse/MODAUD-231) - Handle inventory shadow copy events

--- a/mod-audit-server/src/main/java/org/folio/util/marc/SourceRecordType.java
+++ b/mod-audit-server/src/main/java/org/folio/util/marc/SourceRecordType.java
@@ -12,12 +12,14 @@ import lombok.Getter;
  * Enum values:
  * - MARC_BIB: Represents a bibliographic record.
  * - MARC_AUTHORITY: Represents an authority record.
+ * - MARC_HOLDING: Represents a marc-holding record.
  */
 @Getter
 public enum SourceRecordType {
 
   MARC_BIB("MARC_BIB"),
-  MARC_AUTHORITY("MARC_AUTHORITY");
+  MARC_AUTHORITY("MARC_AUTHORITY"),
+  MARC_HOLDING("MARC_HOLDING");
 
   private final String value;
 


### PR DESCRIPTION
## Purpose
to ensure marc records events processing and marc records audit data saving 

## Approach
* extend SourceRecordType enum to avoid error during event handling and add conditional check for MARC_HOLDING record types to skip audit data saving for such events


## Learning
[MODAUD-250](https://issues.folio.org/browse/MODAUD-250)