### PR TITLE
MODAUD-259: Revert back and prepare next development release iteration as 3.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-## 2.12.0-SNAPSHOT 2025-mm-dd
+## 3.0.0-SNAPSHOT 2025-mm-dd
+* [MODAUD-XXX](https://folio-org.atlassian.net/browse/MODAUD-XXX) - Description
+
+## 2.11.1 2025-04-15 
 * [MODAUD-250](https://folio-org.atlassian.net/browse/MODAUD-250) - Version history of "MARC" records is not tracked
 
 ## 2.11.0 2025-03-14

--- a/mod-audit-server/pom.xml
+++ b/mod-audit-server/pom.xml
@@ -2,13 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-audit-server</artifactId>
-  <version>2.12.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <artifactId>mod-audit</artifactId>
     <groupId>org.folio</groupId>
-    <version>2.12.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <licenses>

--- a/mod-audit-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-audit-server/src/main/resources/templates/db_scripts/schema.json
@@ -143,7 +143,7 @@
     {
       "run": "after",
       "snippetPath": "acquisition/update_to_orders_storage_14.0.ftl",
-      "fromModuleVersion": "mod-audit-2.12.0"
+      "fromModuleVersion": "mod-audit-3.0.0"
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-audit</artifactId>
-  <version>2.12.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <licenses>


### PR DESCRIPTION
## Purpose
Set back the current development iteration as v3.0.0-SNAPSHOT after it was already set as v3.0.0-SNAPSHOT, but then modified to v2.12.0-SNAPSHOT

## Approach
Set back and prepare next development release iteration as 3.0.0-SNAPSHOT

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  - [ ] Check logging
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

[MODAUD-259](https://folio-org.atlassian.net/browse/MODAUD-259)
