### PR TITLE
MODAUD-308: Add pronouns, profilePictureLink, preferredEmailCommunication to user schema

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 ## 3.1.0 In progress
 
+### Bug fixes
+* Track `personal.pronouns`, `personal.profilePictureLink`, and top-level `preferredEmailCommunication` in user version history ([MODAUD-308](https://folio-org.atlassian.net/browse/MODAUD-308))
+
 ### Tech Dept
 * Upgrade to Vert.x v5 ([MODAUD-305](https://folio-org.atlassian.net/browse/MODAUD-305))
 

--- a/mod-audit-server/src/test/java/org/folio/services/diff/user/UserDiffCalculatorTest.java
+++ b/mod-audit-server/src/test/java/org/folio/services/diff/user/UserDiffCalculatorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import org.folio.domain.diff.CollectionChangeDto;
@@ -47,6 +48,48 @@ class UserDiffCalculatorTest {
     assertThat(diff.getFieldChanges())
       .hasSize(1)
       .containsExactly(FieldChangeDto.modified("firstName", "personal.firstName", "John", "Jane"));
+  }
+
+  @Test
+  void shouldDetectPronounsChange() {
+    var oldUser = getMap(new User().withId("1").withPersonal(new Personal__1().withPronouns("she/her")));
+    var newUser = getMap(new User().withId("1").withPersonal(new Personal__1().withPronouns("they/them")));
+
+    var diff = userDiffCalculator.calculateDiff(oldUser, newUser);
+
+    assertThat(diff.getFieldChanges())
+      .hasSize(1)
+      .containsExactly(FieldChangeDto.modified("pronouns", "personal.pronouns", "she/her", "they/them"));
+  }
+
+  @Test
+  void shouldDetectProfilePictureLinkChange() {
+    var oldUser = getMap(new User().withId("1")
+      .withPersonal(new Personal__1().withProfilePictureLink(URI.create("https://example.com/old.png"))));
+    var newUser = getMap(new User().withId("1")
+      .withPersonal(new Personal__1().withProfilePictureLink(URI.create("https://example.com/new.png"))));
+
+    var diff = userDiffCalculator.calculateDiff(oldUser, newUser);
+
+    assertThat(diff.getFieldChanges())
+      .hasSize(1)
+      .containsExactly(FieldChangeDto.modified(
+        "profilePictureLink", "personal.profilePictureLink",
+        "https://example.com/old.png", "https://example.com/new.png"));
+  }
+
+  @Test
+  void shouldDetectPreferredEmailCommunicationChange() {
+    var oldUser = getMap(new User().withId("1"));
+    var newUser = getMap(new User().withId("1"));
+    newUser.put("preferredEmailCommunication", List.of("Support"));
+
+    var diff = userDiffCalculator.calculateDiff(oldUser, newUser);
+
+    assertThat(diff.getCollectionChanges())
+      .hasSize(1)
+      .extracting(CollectionChangeDto::getFullPath)
+      .containsExactly("preferredEmailCommunication");
   }
 
   @Test

--- a/ramls/schemas/external/user.json
+++ b/ramls/schemas/external/user.json
@@ -139,6 +139,16 @@
         "preferredContactTypeId": {
           "description": "Id of user's preferred contact type",
           "type": "string"
+        },
+        "pronouns": {
+          "description": "The user's pronouns",
+          "type": "string",
+          "maxLength": 300
+        },
+        "profilePictureLink": {
+          "description": "Link to the profile picture, or only the id of the /users/profile-picture entry",
+          "type": "string",
+          "format": "uri"
         }
       },
       "additionalProperties": true,
@@ -155,6 +165,16 @@
       "description": "The date for when the user becomes inactive",
       "type": "string",
       "format": "date-time"
+    },
+    "preferredEmailCommunication": {
+      "description": "Preferred email communication types",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["Support", "Programs", "Services"]
+      },
+      "maxItems": 3,
+      "uniqueItems": true
     },
     "createdDate": {
       "description": "Deprecated",


### PR DESCRIPTION
[MODAUD-308](https://folio-org.atlassian.net/browse/MODAUD-308)

## Purpose

Three user fields exist in mod-users' user record but are silently dropped from the user audit log:

- `personal.pronouns`
- `personal.profilePictureLink`
- `preferredEmailCommunication`

When a librarian edits any of these fields and saves, the change is emitted on the user Kafka topic and reaches mod-audit, but it never appears in the version history.

The cause is schema drift. `ramls/schemas/external/user.json` was forked from mod-users in 2021 (commit `f1a28e2`, MODAUD-74) and has only slightly been updated since. Pronouns and profilePictureLink were added to `personal` after the fork; preferredEmailCommunication was added at the top level. Commit `1d7cf41` (MODAUD-181, March 2024) flipped `additionalProperties: true` so unknown fields stop crashing the parser but `org.folio.services.diff.DiffCalculator.calculateDiff` (lines 49-54) still calls `JsonObject.mapTo(getType())`, which discards anything not declared on the typed POJO. JaVers then has nothing to compare for those fields, so they're silently invisible.

## Approach

Add the three missing fields to `ramls/schemas/external/user.json`, copying the definitions verbatim from `mod-users/ramls/userdata.json`.

After this change the generated `User` and `Personal__1` POJOs gain these fields and JaVers reports their changes through the existing `processValueChange` and `processCollectionChange` paths. No code changes were needed.

#### TODOS and Open Questions / Learning

- The same drift class will recur every time a new field is added. This does not only happen to `user.json` but every external raml. Might be approached in a later ticket.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater (three new regression tests cover all three new schema fields)
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes? (Three new optional fields added to `ramls/schemas/external/user.json`. Only an addition. Existing consumers of the typed POJO continue to work unchanged. Audit responses gain the new fields under `fieldChanges`/`collectionChanges` only when those fields are actually edited.)
  - [ ] Did any of the interface versions change? (No bump to `audit-user`; the response shape gains fieldName values that didn't appear before, but this is additive and consumers ignore unknown fieldNames.)
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  - [x] Check logging (no logging changes)
