### PR TITLE
fix(deps): restore unit test execution broken by Surefire and JUnit upgrades

### DIFF
--- a/mod-audit-server/pom.xml
+++ b/mod-audit-server/pom.xml
@@ -97,12 +97,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <version>1.14.4</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>
       <scope>test</scope>

--- a/mod-audit-server/src/test/java/org/folio/mapper/InventoryEntitiesToAuditCollectionMapperTest.java
+++ b/mod-audit-server/src/test/java/org/folio/mapper/InventoryEntitiesToAuditCollectionMapperTest.java
@@ -9,9 +9,11 @@ import java.util.List;
 import java.util.function.Function;
 import org.folio.dao.inventory.InventoryAuditEntity;
 import org.folio.rest.jaxrs.model.InventoryAuditItem;
+import org.folio.utils.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+@UnitTest
 class InventoryEntitiesToAuditCollectionMapperTest {
 
   private InventoryEntitiesToAuditCollectionMapper mapper;

--- a/mod-audit-server/src/test/java/org/folio/rest/impl/CirculationLogsServiceTest.java
+++ b/mod-audit-server/src/test/java/org/folio/rest/impl/CirculationLogsServiceTest.java
@@ -5,10 +5,12 @@ import static org.hamcrest.Matchers.equalTo;
 
 import java.util.stream.Stream;
 
+import org.folio.utils.UnitTest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@UnitTest
 class CirculationLogsServiceTest {
 
   @ParameterizedTest

--- a/mod-audit-server/src/test/java/org/folio/services/diff/user/UserDiffCalculatorTest.java
+++ b/mod-audit-server/src/test/java/org/folio/services/diff/user/UserDiffCalculatorTest.java
@@ -75,7 +75,8 @@ class UserDiffCalculatorTest {
       .hasSize(1)
       .containsExactly(FieldChangeDto.modified(
         "profilePictureLink", "personal.profilePictureLink",
-        "https://example.com/old.png", "https://example.com/new.png"));
+        URI.create("https://example.com/old.png"),
+        URI.create("https://example.com/new.png")));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -157,31 +157,8 @@
         <version>3.5.5</version>
         <configuration>
           <argLine>@{argLine} -Duser.language=en -Duser.region=US</argLine>
-          <!-- TODO: update to version 3.0.0 and remove useSystemClassLoader
-               https://issues.folio.org/browse/FOLIO-1609
-               https://issues.apache.org/jira/browse/SUREFIRE-1588
-          -->
-
           <groups>unit</groups>
-          <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>1.3.2</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Purpose

Unit tests silently stopped running after two Dependabot commits. Every `mvn test`
reported `Tests run: 0` with `BUILD SUCCESS`.
CI was passing on merged PRs with zero test coverage being validated.

The two upgrades that broke it:

- **5dae2de** (dev-deps): bumped `maven-surefire-plugin` 2.22.2 to 3.5.5
- **0fbbb55** (prod-deps): bumped `junit-bom` 5.12.0 to 6.0.3

## Approach

The root cause was `junit-platform-surefire-provider:1.3.2` declared as an explicit
Surefire plugin dependency. This was a workaround added in 2018 before Surefire 2.22.0
introduced native JUnit Platform support. Both Dependabot commits independently broke
this old provider for different reasons:

- **maven-surefire-plugin 2.22.2 to 3.5.5**: Surefire 3.x changed plugin classloading
  such that the old standalone provider conflicts with Surefire's built-in JUnit
  Platform support, causing it to produce 0 tests silently.

- **junit-bom 5.12.0 to 6.0.3**: JUnit 6 removed `CollectionUtils.toUnmodifiableList()`
  from `junit-platform-commons`. The old provider calls this method at startup, causing
  `NoSuchMethodError`. The `junit-platform-runner` module was also fully removed from the
  JUnit 6.0.0 distribution, making the still-declared test dependency a cross-era
  version mismatch on the classpath.

Reverting either commit alone does not restore test execution.

Fix: remove `junit-platform-surefire-provider:1.3.2` and the now-redundant
`junit-jupiter-engine` / `junit-vintage-engine` from the Surefire plugin
`<dependencies>` in root `pom.xml`. Surefire 2.22+ discovers engines automatically
from the project test classpath. Also remove the unused `junit-platform-runner` test
dependency (deprecated since JUnit Platform 1.8, removed in JUnit 6.0.0, no
`@RunWith(JUnitPlatform.class)` usages in this codebase), the stale TODO referencing
FOLIO-1609/SUREFIRE-1588, and `<useSystemClassLoader>false</useSystemClassLoader>`
which the TODO indicated should be dropped when upgrading to Surefire 3.x.

A pre-existing test failure in `UserDiffCalculatorTest` was also uncovered.

Two test classes were also missing the `@UnitTest` annotation and were therefore not
included in the unit test run: `CirculationLogsServiceTest` and
`InventoryEntitiesToAuditCollectionMapperTest`.

## Learning

- Surefire's native JUnit Platform support has been built in since 2.22.0 (2018).
  The old `junit-platform-surefire-provider` was deprecated at that point:
  https://github.com/junit-team/junit5/issues/1536
- `junit-platform-runner` (JUnit 4 `@RunWith` bridge) deprecated in JUnit Platform
  1.8, removed in JUnit 6.0.0: https://docs.junit.org/6.0.0/release-notes/
- The two upgrades are independently sufficient to break the old provider; reverting
  either one alone still leaves tests at 0.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater *(no new production code)*
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.
  - [x] Check logging *(no logging changes)*