### PR TITLE
MODAUD-311 Upgrade dependencies for Kafka v4.2 compatibility

### DIFF
--- a/mod-audit-server/pom.xml
+++ b/mod-audit-server/pom.xml
@@ -29,6 +29,8 @@
     <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
     <assertj.version>3.27.7</assertj.version>
     <javers.version>7.11.2</javers.version>
+    <folio-kafka-wrapper.version>4.1.0-SNAPSHOT</folio-kafka-wrapper.version>
+    <testcontainers-kafka.version>2.0.5</testcontainers-kafka.version>
   </properties>
 
   <dependencies>
@@ -51,7 +53,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>4.0.0</version>
+      <version>${folio-kafka-wrapper.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -64,8 +66,8 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>kafka</artifactId>
-      <version>1.21.4</version>
+      <artifactId>testcontainers-kafka</artifactId>
+      <version>${testcontainers-kafka.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/mod-audit-server/src/test/java/org/folio/TestSuite.java
+++ b/mod-audit-server/src/test/java/org/folio/TestSuite.java
@@ -108,7 +108,7 @@ public class TestSuite {
   }
 
   private static void startKafkaMockServer() {
-    kafkaContainer = new KafkaContainer(DockerImageName.parse("apache/kafka-native:3.8.0"))
+    kafkaContainer = new KafkaContainer(DockerImageName.parse("apache/kafka-native:4.2.1"))
       .withStartupAttempts(3);
     kafkaContainer.start();
   }

--- a/mod-audit-server/src/test/java/org/folio/rest/impl/OrderEventsHandlerMockTest.java
+++ b/mod-audit-server/src/test/java/org/folio/rest/impl/OrderEventsHandlerMockTest.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 import static org.folio.kafka.KafkaTopicNameHelper.getDefaultNameSpace;
 import static org.folio.utils.EntityUtils.createOrderAuditEvent;
 import static org.folio.utils.EntityUtils.createOrderAuditEventWithoutSnapshot;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OrderEventsHandlerMockTest {
 

--- a/mod-audit-server/src/test/java/org/folio/rest/impl/OrderLineEventsHandlerMockTest.java
+++ b/mod-audit-server/src/test/java/org/folio/rest/impl/OrderLineEventsHandlerMockTest.java
@@ -24,7 +24,7 @@ import java.util.Date;
 import java.util.UUID;
 
 import static org.folio.kafka.KafkaTopicNameHelper.getDefaultNameSpace;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OrderLineEventsHandlerMockTest {
 


### PR DESCRIPTION
## Purpose
Upgrade dependencies for Kafka v4.2 compatibility
Jira: https://folio-org.atlassian.net/browse/MODAUD-311

## Approach
- Update version for `folio-kafka-wrapper`
- Update testcontainers dependency
- Fix minor issues in unit tests
